### PR TITLE
Make images go to image type subdirs in archive folder

### DIFF
--- a/exif2timestream.py
+++ b/exif2timestream.py
@@ -376,6 +376,7 @@ def process_image(args):
         archive_image = path.join(
             camera[FIELDS["archive_dest"]],
             camera[FIELDS["expt"]],
+            ext,
             ts_name,
             path.basename(image)
         )


### PR DESCRIPTION
Fixes #12, hopefully

Now, image go to e.g.:

```
./a_data/Archives/BVZ0012/BVZ0012-GC02L-CN650D-Cam01~fullres-orig/jpg/*.JPG
```
